### PR TITLE
[LIVY-41] Accessing sessions by name

### DIFF
--- a/server/src/main/scala/org/apache/livy/server/batch/BatchSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/batch/BatchSession.scala
@@ -33,6 +33,7 @@ import org.apache.livy.utils.{AppInfo, SparkApp, SparkAppListener, SparkProcessB
 @JsonIgnoreProperties(ignoreUnknown = true)
 case class BatchRecoveryMetadata(
     id: Int,
+    name: String,
     appId: Option[String],
     appTag: String,
     owner: String,
@@ -45,6 +46,7 @@ object BatchSession extends Logging {
 
   def create(
       id: Int,
+      name: String,
       request: CreateBatchRequest,
       livyConf: LivyConf,
       owner: String,
@@ -92,6 +94,7 @@ object BatchSession extends Logging {
 
     new BatchSession(
       id,
+      name,
       appTag,
       SessionState.Starting(),
       livyConf,
@@ -108,6 +111,7 @@ object BatchSession extends Logging {
       mockApp: Option[SparkApp] = None): BatchSession = {
     new BatchSession(
       m.id,
+      m.name,
       m.appTag,
       SessionState.Recovering(),
       livyConf,
@@ -122,6 +126,7 @@ object BatchSession extends Logging {
 
 class BatchSession(
     id: Int,
+    name: String,
     appTag: String,
     initialState: SessionState,
     livyConf: LivyConf,
@@ -129,7 +134,7 @@ class BatchSession(
     override val proxyUser: Option[String],
     sessionStore: SessionStore,
     sparkApp: BatchSession => SparkApp)
-  extends Session(id, owner, livyConf) with SparkAppListener {
+  extends Session(id, name, owner, livyConf) with SparkAppListener {
   import BatchSession._
 
   protected implicit def executor: ExecutionContextExecutor = ExecutionContext.global
@@ -169,5 +174,5 @@ class BatchSession(
   override def infoChanged(appInfo: AppInfo): Unit = { this.appInfo = appInfo }
 
   override def recoveryMetadata: RecoveryMetadata =
-    BatchRecoveryMetadata(id, appId, appTag, owner, proxyUser)
+    BatchRecoveryMetadata(id, name, appId, appTag, owner, proxyUser)
 }

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -48,6 +48,7 @@ import org.apache.livy.utils._
 @JsonIgnoreProperties(ignoreUnknown = true)
 case class InteractiveRecoveryMetadata(
     id: Int,
+    name: String,
     appId: Option[String],
     appTag: String,
     kind: Kind,
@@ -65,6 +66,7 @@ object InteractiveSession extends Logging {
 
   def create(
       id: Int,
+      name: String,
       owner: String,
       proxyUser: Option[String],
       livyConf: LivyConf,
@@ -109,6 +111,7 @@ object InteractiveSession extends Logging {
 
     new InteractiveSession(
       id,
+      name,
       None,
       appTag,
       client,
@@ -135,6 +138,7 @@ object InteractiveSession extends Logging {
 
     new InteractiveSession(
       metadata.id,
+      metadata.name,
       metadata.appId,
       metadata.appTag,
       client,
@@ -345,6 +349,7 @@ object InteractiveSession extends Logging {
 
 class InteractiveSession(
     id: Int,
+    name: String,
     appIdHint: Option[String],
     appTag: String,
     client: Option[RSCClient],
@@ -356,7 +361,7 @@ class InteractiveSession(
     override val proxyUser: Option[String],
     sessionStore: SessionStore,
     mockApp: Option[SparkApp]) // For unit test.
-  extends Session(id, owner, livyConf)
+  extends Session(id, name, owner, livyConf)
   with SessionHeartbeat
   with SparkAppListener {
 
@@ -436,8 +441,8 @@ class InteractiveSession(
   override def logLines(): IndexedSeq[String] = app.map(_.log()).getOrElse(sessionLog)
 
   override def recoveryMetadata: RecoveryMetadata =
-    InteractiveRecoveryMetadata(
-      id, appId, appTag, kind, heartbeatTimeout.toSeconds.toInt, owner, proxyUser, rscDriverUri)
+    InteractiveRecoveryMetadata( id, name, appId, appTag, kind, heartbeatTimeout.toSeconds.toInt,
+      owner, proxyUser, rscDriverUri)
 
   override def state: SessionState = {
     if (serverSideState.isInstanceOf[SessionState.Running]) {

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
@@ -53,8 +53,23 @@ class InteractiveSessionServlet(
   override protected def createSession(req: HttpServletRequest): InteractiveSession = {
     val createRequest = bodyAs[CreateInteractiveRequest](req)
     val proxyUser = checkImpersonation(createRequest.proxyUser, req)
+    val sessionId: Int = sessionManager.nextId()
+    val sessionName: String = createRequest.name match {
+      case Some(name) if sessionManager.get(name).isEmpty =>
+        name
+      case Some(name) =>
+        // this does NOT guarantee that by the time this session is ready to be registered in
+        // sessionManager, another with the same name is not registered. But in most cases,
+        // it prevents Livy from submitting applications to Spark.
+        val msg = s"Session $name already exists! " +
+          s"Choose a different name or delete the existing session."
+        throw new IllegalArgumentException(msg)
+      case None =>
+        s"INTERACTIVE-SESSION-$sessionId"
+    }
     InteractiveSession.create(
-      sessionManager.nextId(),
+      sessionId,
+      sessionName,
       remoteUser(req),
       proxyUser,
       livyConf,

--- a/server/src/main/scala/org/apache/livy/sessions/Session.scala
+++ b/server/src/main/scala/org/apache/livy/sessions/Session.scala
@@ -132,7 +132,7 @@ object Session {
   }
 }
 
-abstract class Session(val id: Int, val owner: String, val livyConf: LivyConf)
+abstract class Session(val id: Int, val name: String, val owner: String, val livyConf: LivyConf)
   extends Logging {
 
   import Session._

--- a/server/src/main/scala/org/apache/livy/sessions/SessionManager.scala
+++ b/server/src/main/scala/org/apache/livy/sessions/SessionManager.scala
@@ -73,6 +73,8 @@ class SessionManager[S <: Session, R <: RecoveryMetadata : ClassTag](
 
   protected[this] final val idCounter = new AtomicInteger(0)
   protected[this] final val sessions = mutable.LinkedHashMap[Int, S]()
+  private[this] final val sessionsByName = mutable.Map[String, S]()
+
 
   private[this] final val sessionTimeoutCheck = livyConf.getBoolean(LivyConf.SESSION_TIMEOUT_CHECK)
   private[this] final val sessionTimeout =
@@ -92,12 +94,28 @@ class SessionManager[S <: Session, R <: RecoveryMetadata : ClassTag](
   def register(session: S): S = {
     info(s"Registering new session ${session.id}")
     synchronized {
-      sessions.put(session.id, session)
+      // in InteractiveSessionServlet.createSession() and BatchSessionServlet.createSession(),
+      // Livy checks to make sure another session with the same name does not exist already.
+      // This case should not happen rarely.
+      // already exists. But looking up a session name and adding it to the set of existing sessions
+      // should happen atomically.
+      if (sessionsByName.contains(session.name)) {
+        val msg = s"Session ${session.name} already exists!"
+        error(msg)
+        delete(session)
+        throw new IllegalArgumentException(msg)
+      } else {
+        info(s"sessionNames = ${sessionsByName.keys.mkString}")
+        sessions.put(session.id, session)
+        sessionsByName.put(session.name, session)
+      }
     }
     session
   }
 
   def get(id: Int): Option[S] = sessions.get(id)
+
+  def get(sessionName: String): Option[S] = sessionsByName.get(sessionName)
 
   def size(): Int = sessions.size
 
@@ -113,6 +131,7 @@ class SessionManager[S <: Session, R <: RecoveryMetadata : ClassTag](
         sessionStore.remove(sessionType, session.id)
         synchronized {
           sessions.remove(session.id)
+          sessionsByName.remove(session.name)
         }
       } catch {
         case NonFatal(e) =>

--- a/server/src/test/scala/org/apache/livy/server/SessionServletSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/SessionServletSpec.scala
@@ -32,7 +32,7 @@ object SessionServletSpec {
   val PROXY_USER = "proxyUser"
 
   class MockSession(id: Int, owner: String, livyConf: LivyConf)
-    extends Session(id, owner, livyConf) {
+    extends Session(id, s"Mock Session $id", owner, livyConf) {
 
     case class MockRecoveryMetadata(id: Int) extends RecoveryMetadata()
 

--- a/server/src/test/scala/org/apache/livy/server/batch/BatchSessionSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/batch/BatchSessionSpec.scala
@@ -68,7 +68,7 @@ class BatchSessionSpec
       req.conf = Map("spark.driver.extraClassPath" -> sys.props("java.class.path"))
 
       val conf = new LivyConf().set(LivyConf.LOCAL_FS_WHITELIST, sys.props("java.io.tmpdir"))
-      val batch = BatchSession.create(0, req, conf, null, None, sessionStore)
+      val batch = BatchSession.create(0, "Test Batch Session", req, conf, null, None, sessionStore)
 
       Utils.waitUntil({ () => !batch.state.isActive }, Duration(10, TimeUnit.SECONDS))
       (batch.state match {
@@ -83,7 +83,8 @@ class BatchSessionSpec
       val conf = new LivyConf()
       val req = new CreateBatchRequest()
       val mockApp = mock[SparkApp]
-      val batch = BatchSession.create(0, req, conf, null, None, sessionStore, Some(mockApp))
+      val batch = BatchSession.create(
+        0, "Test Batch Session", req, conf, null, None, sessionStore, Some(mockApp))
 
       val expectedAppId = "APPID"
       batch.appIdKnown(expectedAppId)
@@ -100,7 +101,7 @@ class BatchSessionSpec
       val conf = new LivyConf()
       val req = new CreateBatchRequest()
       val mockApp = mock[SparkApp]
-      val m = BatchRecoveryMetadata(99, None, "appTag", null, None)
+      val m = BatchRecoveryMetadata(99, "Test Batch Session", None, "appTag", null, None)
       val batch = BatchSession.recover(m, conf, sessionStore, Some(mockApp))
 
       batch.state shouldBe a[SessionState.Recovering]

--- a/server/src/test/scala/org/apache/livy/server/interactive/InteractiveSessionSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/interactive/InteractiveSessionSpec.scala
@@ -68,7 +68,8 @@ class InteractiveSessionSpec extends FunSpec
       SparkLauncher.DRIVER_EXTRA_CLASSPATH -> sys.props("java.class.path"),
       RSCConf.Entry.LIVY_JARS.key() -> ""
     )
-    InteractiveSession.create(0, null, None, livyConf, req, sessionStore, mockApp)
+    InteractiveSession.create(
+      0, "Test Interactive Session", null, None, livyConf, req, sessionStore, mockApp)
   }
 
   private def executeStatement(code: String, codeType: Option[String] = None): JValue = {
@@ -247,7 +248,7 @@ class InteractiveSessionSpec extends FunSpec
       when(mockClient.submit(any(classOf[PingJob]))).thenReturn(mock[JobHandle[Void]])
       val m =
         InteractiveRecoveryMetadata(
-          78, None, "appTag", Spark(), 0, null, None, Some(URI.create("")))
+          78, "Test session ", None, "appTag", Spark(), 0, null, None, Some(URI.create("")))
       val s = InteractiveSession.recover(m, conf, sessionStore, None, Some(mockClient))
 
       s.state shouldBe a[SessionState.Recovering]
@@ -261,7 +262,7 @@ class InteractiveSessionSpec extends FunSpec
       val conf = new LivyConf()
       val sessionStore = mock[SessionStore]
       val m = InteractiveRecoveryMetadata(
-        78, Some("appId"), "appTag", Spark(), 0, null, None, None)
+        78, "Test session ", Some("appId"), "appTag", Spark(), 0, null, None, None)
       val s = InteractiveSession.recover(m, conf, sessionStore, None)
 
       s.state shouldBe a[SessionState.Dead]

--- a/server/src/test/scala/org/apache/livy/server/interactive/SessionHeartbeatSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/interactive/SessionHeartbeatSpec.scala
@@ -55,7 +55,8 @@ class SessionHeartbeatSpec extends FunSpec with Matchers {
   }
 
   describe("SessionHeartbeatWatchdog") {
-    abstract class TestSession extends Session(0, null, null) with SessionHeartbeat {}
+    abstract class TestSession
+      extends Session(0, "Test Heart Beat Session", null, null) with SessionHeartbeat {}
     class TestWatchdog(conf: LivyConf)
       extends SessionManager[TestSession, RecoveryMetadata](
         conf,
@@ -68,10 +69,12 @@ class SessionHeartbeatSpec extends FunSpec with Matchers {
     it("should delete only expired sessions") {
       val expiredSession: TestSession = mock[TestSession]
       when(expiredSession.id).thenReturn(0)
+      when(expiredSession.name).thenReturn("expired session")
       when(expiredSession.heartbeatExpired).thenReturn(true)
 
       val nonExpiredSession: TestSession = mock[TestSession]
       when(nonExpiredSession.id).thenReturn(1)
+      when(nonExpiredSession.name).thenReturn("unexpired session")
       when(nonExpiredSession.heartbeatExpired).thenReturn(false)
 
       val n = new TestWatchdog(new LivyConf())

--- a/server/src/test/scala/org/apache/livy/sessions/MockSession.scala
+++ b/server/src/test/scala/org/apache/livy/sessions/MockSession.scala
@@ -19,7 +19,8 @@ package org.apache.livy.sessions
 
 import org.apache.livy.LivyConf
 
-class MockSession(id: Int, owner: String, conf: LivyConf) extends Session(id, owner, conf) {
+class MockSession(id: Int, owner: String, conf: LivyConf, name: String = s"Mock-Session")
+  extends Session(id, name, owner, conf) {
   case class RecoveryMetadata(id: Int) extends Session.RecoveryMetadata()
 
   override val proxyUser = None


### PR DESCRIPTION
This PR enables Livy users to access sessions either by name or by id.

Task-url: https://issues.apache.org/jira/browse/LIVY-41